### PR TITLE
Format the code

### DIFF
--- a/apps/ui/web/elm/App.elm
+++ b/apps/ui/web/elm/App.elm
@@ -16,6 +16,7 @@ import Line
 
 import Conference
 
+
 main =
   Html.programWithFlags
     { init = init
@@ -24,11 +25,13 @@ main =
     , subscriptions = subscriptions
     }
 
+
 -- MODEL
 
 type alias Flags =
   { clientName : String
   }
+
 
 type alias Model =
   { phxSocket : Phoenix.Socket.Socket Msg
@@ -40,203 +43,281 @@ type alias Model =
   , conferenceStatus : String
   }
 
+
 clientsChannel : String -> String
 clientsChannel clientName =
-  "twilio:" ++ clientName
+    "twilio:" ++ clientName
 
-init : Flags -> (Model, Cmd Msg)
+
+init : Flags -> ( Model, Cmd Msg )
 init flags =
-  let
-    channel =
-      Phoenix.Channel.init (clientsChannel flags.clientName)
-    (initSocket, phxCmd) =
-      Phoenix.Socket.init "ws://localhost:5000/socket/websocket"
-      |> Phoenix.Socket.withDebug
-      |> Phoenix.Socket.on "conference_changed" (clientsChannel flags.clientName) ConferenceChanged
-      |> Phoenix.Socket.on "set_token" (clientsChannel flags.clientName) SetupTwilio
-      |> Phoenix.Socket.join channel
-    model =
-      { phxSocket = initSocket
-      , status = "All good"
-      , clientName = flags.clientName
-      , twilioStatus = "All good"
-      , line = Line.initialModel
-      , conference = Nothing
-      , conferenceStatus = "All good"
-      }
-  in
-    ( model, Cmd.map PhoenixMsg phxCmd )
+    let
+        channel =
+            Phoenix.Channel.init (clientsChannel flags.clientName)
+
+        ( initSocket, phxCmd ) =
+            Phoenix.Socket.init "ws://localhost:5000/socket/websocket"
+                |> Phoenix.Socket.withDebug
+                |> Phoenix.Socket.on "conference_changed" (clientsChannel flags.clientName) ConferenceChanged
+                |> Phoenix.Socket.on "set_token" (clientsChannel flags.clientName) SetupTwilio
+                |> Phoenix.Socket.join channel
+
+        model =
+            { phxSocket = initSocket
+            , status = "All good"
+            , clientName = flags.clientName
+            , twilioStatus = "All good"
+            , line = Line.initialModel
+            , conference = Nothing
+            , conferenceStatus = "All good"
+            }
+    in
+        ( model, Cmd.map PhoenixMsg phxCmd )
+
 
 -- UPDATE
 
 type Msg
-  = PhoenixMsg (Phoenix.Socket.Msg Msg)
-  | ConferenceChanged JsEncode.Value
-  | RequestFailed JsEncode.Value
-  | RequestSubmitted JsEncode.Value
-  | TwilioStatusChanged String
-  | SetupTwilio JsEncode.Value
-  | LineMsg Line.Msg
-  | ConferenceMsg Conference.Msg
+    = PhoenixMsg (Phoenix.Socket.Msg Msg)
+    | ConferenceChanged JsEncode.Value
+    | RequestFailed JsEncode.Value
+    | RequestSubmitted JsEncode.Value
+    | TwilioStatusChanged String
+    | SetupTwilio JsEncode.Value
+    | LineMsg Line.Msg
+    | ConferenceMsg Conference.Msg
 
-sendStartCall : Model -> Line.Callee -> (Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg))
+
+sendStartCall : Model -> Line.Callee -> ( Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg) )
 sendStartCall model callee =
-  let
-    payload = (encodedCall callee model.clientName)
-    phxPush =
-      Phoenix.Push.init "start_call" (clientsChannel model.clientName)
-        |> Phoenix.Push.withPayload payload
-        |> Phoenix.Push.onOk RequestSubmitted
-        |> Phoenix.Push.onError RequestFailed
-    (phxSocket, phxCmd) = Phoenix.Socket.push phxPush model.phxSocket
-  in
-    ( phxSocket, phxCmd )
+    let
+        payload =
+            (encodedCall callee model.clientName)
 
-sendAddParticipant : Model -> Line.Callee -> Conference.Model -> (Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg))
+        phxPush =
+            Phoenix.Push.init "start_call" (clientsChannel model.clientName)
+                |> Phoenix.Push.withPayload payload
+                |> Phoenix.Push.onOk RequestSubmitted
+                |> Phoenix.Push.onError RequestFailed
+
+        ( phxSocket, phxCmd ) =
+            Phoenix.Socket.push phxPush model.phxSocket
+    in
+        ( phxSocket, phxCmd )
+
+
+sendAddParticipant : Model -> Line.Callee -> Conference.Model -> ( Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg) )
 sendAddParticipant model callee conference =
-  let
-    payload = (encodedCallWithConference callee model.clientName conference)
-    phxPush =
-      Phoenix.Push.init "request_to_add_participant" (clientsChannel model.clientName)
-        |> Phoenix.Push.withPayload payload
-        |> Phoenix.Push.onOk RequestSubmitted
-        |> Phoenix.Push.onError RequestFailed
-    (phxSocket, phxCmd) = Phoenix.Socket.push phxPush model.phxSocket
-  in
-    ( phxSocket, phxCmd )
+    let
+        payload =
+            (encodedCallWithConference callee model.clientName conference)
 
-sendRequestToCancelPendingParticipant : Model -> Conference.Model -> Conference.CallLeg -> (Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg))
+        phxPush =
+            Phoenix.Push.init "request_to_add_participant" (clientsChannel model.clientName)
+                |> Phoenix.Push.withPayload payload
+                |> Phoenix.Push.onOk RequestSubmitted
+                |> Phoenix.Push.onError RequestFailed
+
+        ( phxSocket, phxCmd ) =
+            Phoenix.Socket.push phxPush model.phxSocket
+    in
+        ( phxSocket, phxCmd )
+
+
+sendRequestToCancelPendingParticipant : Model -> Conference.Model -> Conference.CallLeg -> ( Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg) )
 sendRequestToCancelPendingParticipant model conference callLeg =
-  let
-    payload = (encodedPendingParticipantReference conference callLeg)
-    phxPush =
-      Phoenix.Push.init "request_to_cancel_pending_participant" (clientsChannel model.clientName)
-        |> Phoenix.Push.withPayload payload
-        |> Phoenix.Push.onOk RequestSubmitted
-        |> Phoenix.Push.onError RequestFailed
-    (phxSocket, phxCmd) = Phoenix.Socket.push phxPush model.phxSocket
-  in
-    ( phxSocket, phxCmd )
+    let
+        payload =
+            (encodedPendingParticipantReference conference callLeg)
 
-sendRequestToHangupParticipant : Model -> Conference.Model -> Conference.CallLeg -> (Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg))
+        phxPush =
+            Phoenix.Push.init "request_to_cancel_pending_participant" (clientsChannel model.clientName)
+                |> Phoenix.Push.withPayload payload
+                |> Phoenix.Push.onOk RequestSubmitted
+                |> Phoenix.Push.onError RequestFailed
+
+        ( phxSocket, phxCmd ) =
+            Phoenix.Socket.push phxPush model.phxSocket
+    in
+        ( phxSocket, phxCmd )
+
+
+sendRequestToHangupParticipant : Model -> Conference.Model -> Conference.CallLeg -> ( Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg) )
 sendRequestToHangupParticipant model conference callLeg =
-  let
-    payload = (encodedParticipantReference conference callLeg)
-    phxPush =
-      Phoenix.Push.init "request_to_hangup_participant" (clientsChannel model.clientName)
-        |> Phoenix.Push.withPayload payload
-        |> Phoenix.Push.onOk RequestSubmitted
-        |> Phoenix.Push.onError RequestFailed
-    (phxSocket, phxCmd) = Phoenix.Socket.push phxPush model.phxSocket
-  in
-    ( phxSocket, phxCmd )
+    let
+        payload =
+            (encodedParticipantReference conference callLeg)
 
-update : Msg -> Model -> (Model, Cmd Msg)
+        phxPush =
+            Phoenix.Push.init "request_to_hangup_participant" (clientsChannel model.clientName)
+                |> Phoenix.Push.withPayload payload
+                |> Phoenix.Push.onOk RequestSubmitted
+                |> Phoenix.Push.onError RequestFailed
+
+        ( phxSocket, phxCmd ) =
+            Phoenix.Socket.push phxPush model.phxSocket
+    in
+        ( phxSocket, phxCmd )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-  case msg of
-    TwilioStatusChanged twilioStatus ->
-      (
-        { model | twilioStatus = twilioStatus },
-        Cmd.none
-      )
-    SetupTwilio raw ->
-      let
-        decodeResult = JsDecode.decodeValue decodeTwilioToken raw
-      in
-        case decodeResult of
-          Ok token ->
-            (
-              { model | status = "Twilio token received" },
-              Twilio.setup token
+    case msg of
+        TwilioStatusChanged twilioStatus ->
+            ( { model | twilioStatus = twilioStatus }
+            , Cmd.none
             )
-          Err error ->
-            ({ model | status = error }, Cmd.none )
-    ConferenceChanged raw ->
-      let
-        decodeResult = JsDecode.decodeValue Conference.decodeResponse raw
-      in
-        case decodeResult of
-          Ok response ->
-            (
-              { model | conference = response.conference, conferenceStatus = response.message },
-              Cmd.none
-            )
-          Err error ->
-            ({ model | status = error }, Cmd.none )
-    RequestFailed raw ->
-      let
-        decodeResult = JsDecode.decodeValue decodeCallRequestFailure raw
-      in
-        case decodeResult of
-          Ok message ->
-            ({ model | status = "Request failed with error: " ++ message }, Cmd.none )
-          Err error ->
-            ({ model | status = "Failed to decode call request failure: " ++ error }, Cmd.none )
-    RequestSubmitted raw ->
-      ({ model | status = "Request submitted" }, Cmd.none )
-    LineMsg subMsg ->
-      let
-          ( updatedLineModel, lineCmd ) =
-              Line.update subMsg model.line
-          ( phxSocket, phxCmd ) =
-            case subMsg of
-              (Line.RequestCall callee) ->
-                case model.conference of
-                  Nothing ->
-                    sendStartCall model callee
-                  Just conference ->
-                    sendAddParticipant model callee conference
-              _ ->
-                ( model.phxSocket, Cmd.none )
-        in
-            ( { model | line = updatedLineModel, phxSocket = phxSocket }, Cmd.batch [ Cmd.map LineMsg lineCmd, Cmd.map PhoenixMsg phxCmd ] )
-    ConferenceMsg subMsg ->
-      case model.conference of
-        Nothing ->
-          (model, Cmd.none)
-        Just conference ->
-          let
-              ( updatedConferenceModel, conferenceCmd ) =
-                  Conference.update subMsg conference
-              ( phxSocket, phxCmd ) =
-                case subMsg of
-                  (Conference.Cancel callLeg) ->
-                    sendRequestToCancelPendingParticipant model updatedConferenceModel callLeg
-                  (Conference.Hangup callLeg) ->
-                    sendRequestToHangupParticipant model updatedConferenceModel callLeg
+
+        SetupTwilio raw ->
+            let
+                decodeResult =
+                    JsDecode.decodeValue decodeTwilioToken raw
             in
-                ( { model | conference = Just updatedConferenceModel, phxSocket = phxSocket }, Cmd.batch [ Cmd.map ConferenceMsg conferenceCmd, Cmd.map PhoenixMsg phxCmd ] )
-    PhoenixMsg msg ->
-      let
-        ( phxSocket, phxCmd ) = Phoenix.Socket.update msg model.phxSocket
-      in
-        ( { model | phxSocket = phxSocket }
-          , Cmd.map PhoenixMsg phxCmd
-        )
+                case decodeResult of
+                    Ok token ->
+                        ( { model | status = "Twilio token received" }
+                        , Twilio.setup token
+                        )
+
+                    Err error ->
+                        ( { model | status = error }
+                        , Cmd.none
+                        )
+
+        ConferenceChanged raw ->
+            let
+                decodeResult =
+                    JsDecode.decodeValue Conference.decodeResponse raw
+            in
+                case decodeResult of
+                    Ok response ->
+                        ( { model
+                              | conference = response.conference
+                              , conferenceStatus = response.message
+                          }
+                        , Cmd.none
+                        )
+
+                    Err error ->
+                        ( { model | status = error }
+                        , Cmd.none
+                        )
+
+        RequestFailed raw ->
+            let
+                decodeResult =
+                    JsDecode.decodeValue decodeCallRequestFailure raw
+            in
+                case decodeResult of
+                    Ok message ->
+                        ( { model | status = "Request failed with error: " ++ message }
+                        , Cmd.none
+                        )
+
+                    Err error ->
+                        ( { model | status = "Failed to decode call request failure: " ++ error }
+                        , Cmd.none
+                        )
+
+        RequestSubmitted raw ->
+            ( { model | status = "Request submitted" }
+            , Cmd.none
+            )
+
+        LineMsg subMsg ->
+            let
+                ( updatedLineModel, lineCmd ) =
+                    Line.update subMsg model.line
+
+                ( phxSocket, phxCmd ) =
+                    case subMsg of
+                        (Line.RequestCall callee) ->
+                            case model.conference of
+                                Nothing ->
+                                    sendStartCall model callee
+
+                                Just conference ->
+                                    sendAddParticipant model callee conference
+
+                        _ ->
+                            ( model.phxSocket, Cmd.none )
+            in
+                ( { model
+                      | line = updatedLineModel
+                      , phxSocket = phxSocket
+                  }
+                , Cmd.batch [ Cmd.map LineMsg lineCmd
+                            , Cmd.map PhoenixMsg phxCmd
+                            ]
+                )
+
+        ConferenceMsg subMsg ->
+            case model.conference of
+                Nothing ->
+                    ( model, Cmd.none )
+
+                Just conference ->
+                    let
+                        ( updatedConferenceModel, conferenceCmd ) =
+                            Conference.update subMsg conference
+
+                        ( phxSocket, phxCmd ) =
+                            case subMsg of
+                                (Conference.Cancel callLeg) ->
+                                    sendRequestToCancelPendingParticipant model updatedConferenceModel callLeg
+
+                                (Conference.Hangup callLeg) ->
+                                    sendRequestToHangupParticipant model updatedConferenceModel callLeg
+                    in
+                        ( { model
+                              | conference = Just updatedConferenceModel
+                              , phxSocket = phxSocket
+                          }
+                        , Cmd.batch [ Cmd.map ConferenceMsg conferenceCmd
+                                    , Cmd.map PhoenixMsg phxCmd
+                                    ]
+                        )
+
+        PhoenixMsg msg ->
+            let
+                ( phxSocket, phxCmd ) =
+                    Phoenix.Socket.update msg model.phxSocket
+            in
+                ( { model | phxSocket = phxSocket }
+                , Cmd.map PhoenixMsg phxCmd
+                )
+
 
 -- VIEW
 
 view : Model -> Html Msg
 view model =
-  div [ class "jumbotron" ] [
-      h1 [] [ text ("Welcome, " ++ model.clientName ++ "!") ]
-    , p [] [ text "Talkbox is a proof of concept in building browser-based telephony applications using functional programming languages." ]
-    --, h4 [] [ text "Elm" ]
-    --, p [] [ text model.status ]
-    --, h4 [] [ text "Twilio" ]
-    --, p [] [ text (toString model.twilioStatus) ]
-    --, h4 [] [ text "Conference" ]
-    --, p [] [ text (toString model.conferenceStatus) ]
-    , case model.conference of
-        Nothing ->
-          Html.map LineMsg (Line.view model.line)
-        Just conference ->
-          case conference.pending_participant of
-            Nothing ->
-              p [] [Html.map ConferenceMsg (Conference.view conference), Html.map LineMsg (Line.view model.line)]
-            Just _ ->
-              p [] [Html.map ConferenceMsg (Conference.view conference)]
-  ]
+    div [ class "jumbotron" ]
+        [ h1 [ ] [ text ("Welcome, " ++ model.clientName ++ "!") ]
+        , p [ ] [ text "Talkbox is a proof of concept in building browser-based telephony applications using functional programming languages." ]
+        --, h4 [] [ text "Elm" ]
+        --, p [] [ text model.status ]
+        --, h4 [] [ text "Twilio" ]
+        --, p [] [ text (toString model.twilioStatus) ]
+        --, h4 [] [ text "Conference" ]
+        --, p [] [ text (toString model.conferenceStatus) ]
+        , case model.conference of
+              Nothing ->
+                  Html.map LineMsg (Line.view model.line)
+
+              Just conference ->
+                  case conference.pending_participant of
+                      Nothing ->
+                          p [ ]
+                            [ Html.map ConferenceMsg (Conference.view conference)
+                            , Html.map LineMsg (Line.view model.line)
+                            ]
+
+                      Just _ ->
+                          p [ ]
+                            [ Html.map ConferenceMsg (Conference.view conference) ]
+        ]
+
 
 -- SUBSCRIPTIONS
 
@@ -247,38 +328,48 @@ subscriptions model =
     , Phoenix.Socket.listen model.phxSocket PhoenixMsg
     ]
 
+
 -- JSON
 
 encodedCall: String -> String -> JsDecode.Value
 encodedCall callee user =
     JsEncode.object
-      [ ("callee", JsEncode.string callee)
-      , ("user", JsEncode.string user)]
+      [ ( "callee", JsEncode.string callee )
+      , ( "user", JsEncode.string user )
+      ]
+
 
 encodedCallWithConference: String -> String -> Conference.Model -> JsDecode.Value
 encodedCallWithConference callee chair conference =
     JsEncode.object
-      [ ("callee", JsEncode.string callee)
-      , ("chair", JsEncode.string chair)
-      , ("conference", JsEncode.string conference.identifier) ]
+      [ ( "callee", JsEncode.string callee )
+      , ( "chair", JsEncode.string chair )
+      , ( "conference", JsEncode.string conference.identifier )
+      ]
+
 
 encodedPendingParticipantReference: Conference.Model -> Conference.CallLeg -> JsDecode.Value
 encodedPendingParticipantReference conference callLeg =
     JsEncode.object
-      [ ("conference", JsEncode.string conference.identifier)
-      , ("chair", JsEncode.string conference.chair.identifier)
-      , ("pending_participant", JsEncode.string callLeg.identifier) ]
+      [ ( "conference", JsEncode.string conference.identifier )
+      , ( "chair", JsEncode.string conference.chair.identifier )
+      , ( "pending_participant", JsEncode.string callLeg.identifier )
+      ]
+
 
 encodedParticipantReference: Conference.Model -> Conference.CallLeg -> JsDecode.Value
 encodedParticipantReference conference callLeg =
     JsEncode.object
-      [ ("conference", JsEncode.string conference.identifier)
-      , ("chair", JsEncode.string conference.chair.identifier)
-      , ("call_sid", JsEncode.string (Maybe.withDefault "" callLeg.callSid)) ]
+      [ ( "conference", JsEncode.string conference.identifier )
+      , ( "chair", JsEncode.string conference.chair.identifier )
+      , ( "call_sid", JsEncode.string (Maybe.withDefault "" callLeg.callSid) )
+      ]
+
 
 decodeCallRequestFailure: JsDecode.Decoder String
 decodeCallRequestFailure =
   JsDecode.at ["reason"] JsDecode.string
+
 
 decodeTwilioToken: JsDecode.Decoder String
 decodeTwilioToken =

--- a/apps/ui/web/static/vendor/app.js
+++ b/apps/ui/web/static/vendor/app.js
@@ -1564,8 +1564,7 @@ function toString(v)
 	var type = typeof v;
 	if (type === 'function')
 	{
-		var name = v.func ? v.func.name : v.name;
-		return '<function' + (name === '' ? '' : ':') + name + '>';
+		return '<function>';
 	}
 
 	if (type === 'boolean')
@@ -2072,6 +2071,13 @@ var _elm_lang$core$List$sortWith = _elm_lang$core$Native_List.sortWith;
 var _elm_lang$core$List$sortBy = _elm_lang$core$Native_List.sortBy;
 var _elm_lang$core$List$sort = function (xs) {
 	return A2(_elm_lang$core$List$sortBy, _elm_lang$core$Basics$identity, xs);
+};
+var _elm_lang$core$List$singleton = function (value) {
+	return {
+		ctor: '::',
+		_0: value,
+		_1: {ctor: '[]'}
+	};
 };
 var _elm_lang$core$List$drop = F2(
 	function (n, list) {
@@ -3520,15 +3526,8 @@ function setupIncomingPort(name, callback)
 		sentBeforeInit.push(value);
 	}
 
-	function postInitSend(incomingValue)
+	function postInitSend(value)
 	{
-		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
-		if (result.ctor === 'Err')
-		{
-			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
-		}
-
-		var value = result._0;
 		var temp = subs;
 		while (temp.ctor !== '[]')
 		{
@@ -3539,7 +3538,13 @@ function setupIncomingPort(name, callback)
 
 	function send(incomingValue)
 	{
-		currentSend(incomingValue);
+		var result = A2(_elm_lang$core$Json_Decode$decodeValue, converter, incomingValue);
+		if (result.ctor === 'Err')
+		{
+			throw new Error('Trying to send an unexpected type of value through port `' + name + '`:\n' + result._0);
+		}
+
+		currentSend(result._0);
 	}
 
 	return { send: send };
@@ -4160,7 +4165,7 @@ function endsWith(sub, str)
 function indexes(sub, str)
 {
 	var subLen = sub.length;
-	
+
 	if (subLen < 1)
 	{
 		return _elm_lang$core$Native_List.Nil;
@@ -4173,74 +4178,78 @@ function indexes(sub, str)
 	{
 		is.push(i);
 		i = i + subLen;
-	}	
-	
+	}
+
 	return _elm_lang$core$Native_List.fromArray(is);
 }
+
 
 function toInt(s)
 {
 	var len = s.length;
+
+	// if empty
 	if (len === 0)
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+		return intErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
+
+	// if hex
+	var c = s[0];
+	if (c === '0' && s[1] === 'x')
 	{
-		if (len === 1)
+		for (var i = 2; i < len; ++i)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			var c = s[i];
+			if (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'))
+			{
+				continue;
+			}
+			return intErr(s);
 		}
-		start = 1;
+		return _elm_lang$core$Result$Ok(parseInt(s, 16));
 	}
-	for (var i = start; i < len; ++i)
+
+	// is decimal
+	if (c > '9' || (c < '0' && c !== '-' && c !== '+'))
+	{
+		return intErr(s);
+	}
+	for (var i = 1; i < len; ++i)
 	{
 		var c = s[i];
 		if (c < '0' || '9' < c)
 		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int" );
+			return intErr(s);
 		}
 	}
+
 	return _elm_lang$core$Result$Ok(parseInt(s, 10));
 }
 
+function intErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to an Int");
+}
+
+
 function toFloat(s)
 {
-	var len = s.length;
-	if (len === 0)
+	// check if it is a hex, octal, or binary number
+	if (s.length === 0 || /[\sxbo]/.test(s))
 	{
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
+		return floatErr(s);
 	}
-	var start = 0;
-	if (s[0] === '-')
-	{
-		if (len === 1)
-		{
-			return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-		}
-		start = 1;
-	}
-	var dotCount = 0;
-	for (var i = start; i < len; ++i)
-	{
-		var c = s[i];
-		if ('0' <= c && c <= '9')
-		{
-			continue;
-		}
-		if (c === '.')
-		{
-			dotCount += 1;
-			if (dotCount <= 1)
-			{
-				continue;
-			}
-		}
-		return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float" );
-	}
-	return _elm_lang$core$Result$Ok(parseFloat(s));
+	var n = +s;
+	// faster isNaN check
+	return n === n ? _elm_lang$core$Result$Ok(n) : floatErr(s);
 }
+
+function floatErr(s)
+{
+	return _elm_lang$core$Result$Err("could not convert string '" + s + "' to a Float");
+}
+
 
 function toList(str)
 {
@@ -5695,11 +5704,6 @@ function badToString(problem)
 				problem = problem.rest;
 				break;
 
-			case 'index':
-				context += '[' + problem.index + ']';
-				problem = problem.rest;
-				break;
-
 			case 'oneOf':
 				var problems = problem.problems;
 				for (var i = 0; i < problems.length; i++)
@@ -6431,9 +6435,9 @@ function on(name, options, decoder)
 
 function equalEvents(a, b)
 {
-	if (!a.options === b.options)
+	if (a.options !== b.options)
 	{
-		if (a.stopPropagation !== b.stopPropagation || a.preventDefault !== b.preventDefault)
+		if (a.options.stopPropagation !== b.options.stopPropagation || a.options.preventDefault !== b.options.preventDefault)
 		{
 			return false;
 		}
@@ -7709,7 +7713,7 @@ function normalRenderer(parentNode, view)
 var rAF =
 	typeof requestAnimationFrame !== 'undefined'
 		? requestAnimationFrame
-		: function(callback) { callback(); };
+		: function(callback) { setTimeout(callback, 1000 / 60); };
 
 function makeStepper(domNode, view, initialVirtualNode, eventNode)
 {


### PR DESCRIPTION
This change introduces formatting recommended in official style-guide.

Couple points from the documentation:

- Always have type annotations on top-level definitions.
- Always have 2 empty lines between top-level declarations.
- Always bring the body of the declaration down one line.

You can find more [here](http://elm-lang.org/docs/style-guide).

Something that is not mentioned here is difference of spacing applied for tuples
and for describing of application-precedence:

* There is additional space for tuples:

  ```elm
  ( arg1, arg2 )
  ```

* There is no additional space for binding function arguments

  ```elm
  myFun 1, (otherFun 2)
  ```

This makes reading code a little bit faster, consider this as an example:

```elm
sendStartCall : Model -> Line.Callee -> ( Phoenix.Socket.Socket Msg, Cmd (Phoenix.Socket.Msg Msg) )
```

It's much faster to understand, that the function returns a tuple, where the
second element is a `Cmd`...

If you're happy with these changes, I can take a look at other Elm files.