### PR TITLE
Handle when the call to the pending participant fails to initiate

### DIFF
--- a/apps/router/lib/router.ex
+++ b/apps/router/lib/router.ex
@@ -18,9 +18,9 @@ defmodule Router do
       case Telephony.initiate_conference(event.user, event.callee) do
         {:ok, conference} ->
           Router.Web.broadcast(event.user, "Starting call", conference)
-        {:error, message} ->
+        {:error, message, conference} ->
           # TODO: try to fetch the conference for the user and return it?
-          Router.Web.broadcast(event.user, "Error starting call: #{message}", nil)
+          Router.Web.broadcast(event.user, "Error starting call: #{message}", conference)
       end
     end
   end
@@ -66,13 +66,18 @@ defmodule Router do
   defimpl Routing, for: Events.ParticipantJoinedConference do
     @spec routing(Events.ParticipantJoinedConference.t) :: any
     def routing(event) do
-      conference = Telephony.call_or_promote_pending_participant(
+      result = Telephony.call_or_promote_pending_participant(
         %Telephony.Conference.ParticipantReference{
           chair: event.chair,
           identifier: event.conference,
           conference_sid: event.conference_sid,
           participant_call_sid: event.call_sid})
-      Router.Web.broadcast(event.chair, "Someone joined", conference)
+      case result do
+        {:ok, conference} ->
+          Router.Web.broadcast(event.chair, "Someone joined", conference)
+        {:error, message, conference} ->
+          Router.Web.broadcast(event.chair, "Failed to join participant to conference due to: #{message}", conference)
+      end
     end
   end
 
@@ -108,11 +113,17 @@ defmodule Router do
   defimpl Routing, for: Events.ChairRequestsToAddParticipant do
     @spec routing(Events.ChairRequestsToAddParticipant.t) :: any
     def routing(event) do
-      Telephony.add_participant(
+      result = Telephony.add_participant(
         %Telephony.Conference.PendingParticipantReference{
           chair: event.chair,
           identifier: event.conference,
           pending_participant_identifier: event.pending_participant})
+      case result do
+        {:ok, conference} ->
+          Router.Web.broadcast(event.chair, "Adding participant", conference)
+        {:error, message, conference} ->
+          Router.Web.broadcast(event.chair, "Failed to add participant due to: #{message}", conference)
+      end
     end
   end
 


### PR DESCRIPTION
For example, if an invalid number is submitted, Twilio will return an error. The app will now handle this scenario by clearing the pending participant and updating the UI.